### PR TITLE
added some base data source to be used with other providers

### DIFF
--- a/dcos/data_source_dcos_base_url.go
+++ b/dcos/data_source_dcos_base_url.go
@@ -1,0 +1,32 @@
+package dcos
+
+import (
+	// "github.com/dcos/client-go/dcos"
+
+	"github.com/dcos/client-go/dcos"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceDcosBaseURL() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceDcosBaseURLRead,
+		Schema: map[string]*schema.Schema{
+			"url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceDcosBaseURLRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*dcos.APIClient)
+	//ctx := context.TODO()
+
+	dcosConfig := client.CurrentDCOSConfig()
+	url := dcosConfig.URL()
+	d.Set("url", url)
+	d.SetId(url)
+
+	return nil
+}

--- a/dcos/data_source_dcos_token.go
+++ b/dcos/data_source_dcos_token.go
@@ -1,0 +1,32 @@
+package dcos
+
+import (
+	// "github.com/dcos/client-go/dcos"
+
+	"github.com/dcos/client-go/dcos"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceDcosToken() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceDcosTokenRead,
+		Schema: map[string]*schema.Schema{
+			"token": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceDcosTokenRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*dcos.APIClient)
+	//ctx := context.TODO()
+
+	dcosConfig := client.CurrentDCOSConfig()
+	token := dcosConfig.ACSToken()
+	d.Set("token", token)
+	d.SetId(token)
+
+	return nil
+}

--- a/dcos/provider.go
+++ b/dcos/provider.go
@@ -3,6 +3,7 @@ package dcos
 import (
 	"context"
 	"fmt"
+
 	"github.com/dcos/client-go/dcos"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
@@ -60,8 +61,10 @@ func Provider() terraform.ResourceProvider {
 			"dcos_job_schedule":        resourceDcosJobSchedule(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"dcos_service": dataSourceDcosService(),
-			"dcos_job":     dataSourceDcosJob(),
+			"dcos_service":  dataSourceDcosService(),
+			"dcos_job":      dataSourceDcosJob(),
+			"dcos_token":    dataSourceDcosToken(),
+			"dcos_base_url": dataSourceDcosBaseURL(),
 		},
 		ConfigureFunc: providerConfigure,
 	}


### PR DESCRIPTION
This data resources allow users to use the dcos token and the dcos base url with other providers like marathon or kubernetes