### PR TITLE
Fixing package_repo index property

### DIFF
--- a/dcos/resource_dcos_package_repo.go
+++ b/dcos/resource_dcos_package_repo.go
@@ -140,6 +140,9 @@ func resourceDcosPackageRepoRead(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
+	// We are intentionally not reading the `index` property because
+	// it is only used as hinting during creation.
+
 	// Otherwise such repo was not found
 	d.SetId("")
 	return nil


### PR DESCRIPTION
This commit ensures the new `index` property has a `ForceNew: true` attribute, since the resource does not provide an `Update` method.