### PR TITLE
Pod healthchecks for exec and http {WIP}

### DIFF
--- a/dcos/resource_dcos_marathon_pod.go
+++ b/dcos/resource_dcos_marathon_pod.go
@@ -656,6 +656,7 @@ func schemaToMarathonPod(d *schema.ResourceData) (*marathon.Pod, error) {
 
 						if len(hc) > 0 {
 							execHealthCheck := marathon.NewCommandHealthCheck()
+							h = hc[0].(map[string]interface{})
 
 							if v, ok := h["command_shell"]; ok {
 								execHealthCheck.Command = marathon.PodCommand{}

--- a/dcos/resource_dcos_marathon_pod.go
+++ b/dcos/resource_dcos_marathon_pod.go
@@ -655,7 +655,6 @@ func schemaToMarathonPod(d *schema.ResourceData) (*marathon.Pod, error) {
 						hc := hv.([]interface{})
 
 						if len(hc) > 0 {
-							//h := hc[0].(map[string]interface{})
 							execHealthCheck := marathon.NewCommandHealthCheck()
 
 							if v, ok := h["command_shell"]; ok {
@@ -690,7 +689,6 @@ func schemaToMarathonPod(d *schema.ResourceData) (*marathon.Pod, error) {
 						hh := hv.([]interface{})
 
 						if len(hh) > 0 {
-							//h := hh[0].(map[string]interface{})
 							httpHealthCheck := marathon.NewHTTPHealthCheck()
 
 							if v, ok := h["path"]; ok {

--- a/dcos/resource_dcos_marathon_pod.go
+++ b/dcos/resource_dcos_marathon_pod.go
@@ -691,6 +691,7 @@ func schemaToMarathonPod(d *schema.ResourceData) (*marathon.Pod, error) {
 						hh := hv.([]interface{})
 
 						if len(hh) > 0 {
+							h := hh[0].(map[string]interface{})
 							httpHealthCheck := marathon.NewHTTPHealthCheck()
 
 							if v, ok := h["path"]; ok {

--- a/dcos/resource_dcos_marathon_pod.go
+++ b/dcos/resource_dcos_marathon_pod.go
@@ -662,6 +662,7 @@ func schemaToMarathonPod(d *schema.ResourceData) (*marathon.Pod, error) {
 								execHealthCheck.Command.Shell = v.(string)
 
 							}
+							healthcheck.Exec = execHealthCheck
 						}
 					}
 

--- a/dcos/resource_dcos_marathon_pod.go
+++ b/dcos/resource_dcos_marathon_pod.go
@@ -652,12 +652,17 @@ func schemaToMarathonPod(d *schema.ResourceData) (*marathon.Pod, error) {
 					healthcheck := marathon.NewPodHealthCheck()
 
 					if hv, ok := h["exec"]; ok {
-						hc := hv.(map[string]interface{})
-						execHealthCheck := marathon.NewCommandHealthCheck()
+						hc := hv.([]interface{})
 
-						if v, ok := hc["command_shell"]; ok {
-							execHealthCheck.Command = marathon.PodCommand{}
-							execHealthCheck.Command.Shell = v.(string)
+						if len(hc) > 0 {
+							//h := hc[0].(map[string]interface{})
+							execHealthCheck := marathon.NewCommandHealthCheck()
+
+							if v, ok := h["command_shell"]; ok {
+								execHealthCheck.Command = marathon.PodCommand{}
+								execHealthCheck.Command.Shell = v.(string)
+
+							}
 						}
 					}
 
@@ -682,22 +687,26 @@ func schemaToMarathonPod(d *schema.ResourceData) (*marathon.Pod, error) {
 					}
 
 					if hv, ok := h["http"]; ok {
-						hh := hv.([]map[string]interface{})
-						httpHealthCheck := marathon.NewHTTPHealthCheck()
+						hh := hv.([]interface{})
 
-						if v, ok := hh[0]["path"]; ok {
-							httpHealthCheck.SetPath(v.(string))
+						if len(hh) > 0 {
+							//h := hh[0].(map[string]interface{})
+							httpHealthCheck := marathon.NewHTTPHealthCheck()
+
+							if v, ok := h["path"]; ok {
+								httpHealthCheck.SetPath(v.(string))
+							}
+
+							if v, ok := h["scheme"]; ok {
+								httpHealthCheck.SetScheme(v.(string))
+							}
+
+							if v, ok := h["endpoint"]; ok {
+								httpHealthCheck.SetEndpoint(v.(string))
+							}
+
+							healthcheck.SetHTTPHealthCheck(httpHealthCheck)
 						}
-
-						if v, ok := hh[0]["scheme"]; ok {
-							httpHealthCheck.SetScheme(v.(string))
-						}
-
-						if v, ok := hh[0]["endpoint"]; ok {
-							httpHealthCheck.SetEndpoint(v.(string))
-						}
-
-						healthcheck.SetHTTPHealthCheck(httpHealthCheck)
 					}
 					container.SetHealthCheck(healthcheck)
 				}

--- a/dcos/resource_dcos_marathon_pod.go
+++ b/dcos/resource_dcos_marathon_pod.go
@@ -1162,11 +1162,11 @@ func resourceDcosMarathonPodRead(d *schema.ResourceData, meta interface{}) error
 				http[0]["path"] = h.HTTP.Endpoint
 				http[0]["scheme"] = h.HTTP.Scheme
 				http[0]["endpoint"] = h.HTTP.Endpoint
+				healthchecks[0]["http"] = http
 				exec := make([]map[string]interface{}, 1)
 				exec[0] = make(map[string]interface{})
 				exec[0]["command_shell"] = h.Exec.Command
-
-				healthchecks[0]["http"] = http
+				exec[0]["exec"] = exec
 
 				c["health_check"] = healthchecks
 			}


### PR DESCRIPTION
- Adding feature to support exec on healthchecks
- Resolving issues with HTTP argument for healthchecks 
```
panic: interface conversion: interface {} is []interface {}, not []map[string]interface {}
2019-10-25T16:32:54.124-0400 [DEBUG] plugin.terraform-provider-dcos_v0.0.1:
2019-10-25T16:32:54.124-0400 [DEBUG] plugin.terraform-provider-dcos_v0.0.1: goroutine 44 [running]:
2019-10-25T16:32:54.124-0400 [DEBUG] plugin.terraform-provider-dcos_v0.0.1: github.com/mesosphere/terraform-provider-dcos/dcos.schemaToMarathonPod(0xc000206310, 0x1d66b60, 0xc0004e4230, 0xc000660580)
2019-10-25T16:32:54.124-0400 [DEBUG] plugin.terraform-provider-dcos_v0.0.1: 	/Users/westonbassler/Documents/git-repos/dcos-provider/terraform-provider-dcos/dcos/resource_dcos_marathon_pod.go:661 +0x56d3
```