### PR TITLE
Adding dcos_service_http_request resource

### DIFF
--- a/dcos/provider.go
+++ b/dcos/provider.go
@@ -71,6 +71,8 @@ func Provider() terraform.ResourceProvider {
 
 			"dcos_marathon_app": resourceDcosMarathonApp(),
 			"dcos_marathon_pod": resourceDcosMarathonPod(),
+
+			"dcos_service_http_request": resourceDcosServiceHttpRequest(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"dcos_base_url":        dataSourceDcosBaseURL(),

--- a/dcos/resource_dcos_service_http_request.go
+++ b/dcos/resource_dcos_service_http_request.go
@@ -1,0 +1,163 @@
+package dcos
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/dcos/client-go/dcos"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceDcosServiceHttpRequest() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDcosServiceHttpRequestCreate,
+		Read:   resourceDcosServiceHttpRequestRead,
+		Delete: resourceDcosServiceHttpRequestDelete,
+
+		SchemaVersion: 1,
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"service_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the service on DC/OS.",
+			},
+			"path": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Default:     "/",
+				Description: "The path within the service URL.",
+			},
+			"run_on": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Default:     "create",
+				Description: "At which lifetime of this resource to make the request.",
+			},
+			"method": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Default:     "GET",
+				Description: "The method of the HTTP request to place.",
+			},
+			"header": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Optional HTTP headers to include",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"body": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Default:     "",
+				Description: "The raw body to include in the request.",
+			},
+		},
+	}
+}
+
+func placeRequest(d *schema.ResourceData, meta interface{}) error {
+	apiClient := meta.(*dcos.APIClient)
+	config := apiClient.CurrentDCOSConfig()
+
+	cfgHeaders := d.Get("header").([]interface{})
+	cfgServiceName := d.Get("service_name").(string)
+	cfgPath := d.Get("path").(string)
+	cfgBody := []byte(d.Get("body").(string))
+	cfgMethod := d.Get("method").(string)
+
+	url := fmt.Sprintf("%s/service/%s%s", config.URL(), cfgServiceName, cfgPath)
+
+	log.Printf("[TRACE] Posting body: %s", cfgBody)
+
+	request, err := http.NewRequest(cfgMethod, url, bytes.NewReader(cfgBody))
+	if err != nil {
+		return fmt.Errorf("Unable to prepare request: %s", err.Error())
+	}
+
+	request.Header.Add("Authorization", config.ACSToken())
+	for _, hdr := range cfgHeaders {
+		if recMap, ok := hdr.(map[string]interface{}); ok {
+			if iName, ok := recMap["name"]; ok {
+				if name, ok := iName.(string); ok {
+					if iValue, ok := recMap["value"]; ok {
+						if value, ok := iValue.(string); ok {
+							request.Header.Add(name, value)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	response, err := apiClient.HTTPClient().Do(request)
+	if err != nil {
+		return fmt.Errorf("Unable to place request: %s", err.Error())
+	}
+	defer response.Body.Close()
+
+	log.Printf("[TRACE] Server responded with %s", response.Status)
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return fmt.Errorf("Server on %s responded with %s", url, response.Status)
+	}
+
+	return nil
+}
+
+func resourceDcosServiceHttpRequestCreate(d *schema.ResourceData, meta interface{}) error {
+	runTrigger := d.Get("run_on").(string)
+
+	if runTrigger == "create" {
+		err := placeRequest(d, meta)
+		if err != nil {
+			return err
+		}
+	}
+
+	d.SetId("ok")
+
+	return nil
+}
+
+func resourceDcosServiceHttpRequestRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceDcosServiceHttpRequestDelete(d *schema.ResourceData, meta interface{}) error {
+	runTrigger := d.Get("run_on").(string)
+
+	if runTrigger == "delete" {
+		err := placeRequest(d, meta)
+		if err != nil {
+			return err
+		}
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/docs/content/docs/resources/dcos_service_http_request.md
+++ b/docs/content/docs/resources/dcos_service_http_request.md
@@ -1,0 +1,57 @@
+---
+title: "dcos_service_http_request"
+type: docs
+weight: 4
+---
+
+# Resource: dcos_service_http_request
+
+Performs an HTTP request to a DC/OS service, exposed through the Admin Router.
+
+## Example Usage
+```hcl
+# POST some data to an HTTP service 
+resource "dcos_service_http_request" "some_config" {
+  service_name = "my-service"
+  path         = "/configure"
+  method       = "POST"
+
+  header {
+    name  = "Content-Type"
+    value = "application/json"
+  }
+
+  body = <<EOF
+    {
+        "setting-a": "foo",
+        "setting-b": "bar"
+    }
+EOF
+}
+```
+
+## Argument Reference
+The following arguments are supported
+
+{{< tf_arguments >}}
+    {{< tf_arg name="service_name" required="true" >}}
+        The name of the DC/OS service to target. This is the same as the marathon app id without the leading path (eg. `my-group/my-service`).
+    {{</ tf_arg >}}
+    {{< tf_arg name="path" default="/" >}}
+        The path under the exposed service endpoint to access (including the leading slash). The final URL will be composed as: `https://<cluster>/service/<service><path>`.
+    {{</ tf_arg >}}
+    {{< tf_arg name="method" default="GET" >}}
+        The HTTP method to use for performing this request. Can be any valid HTTP verb (eg. "GET", "POST", "PUT", "DELETE") etc.
+    {{</ tf_arg >}}
+    {{< tf_arg name="header" >}}
+        One or more headers to include in the request. The Authorisation header is always included.
+    {{</ tf_arg >}}
+    {{< tf_arg name="body" default="" >}}
+        The raw body of the HTTP request.
+    {{</ tf_arg >}}
+    {{< tf_arg name="run_on" default="create" >}}
+        Specify *when* to perform the HTTP request. There are two options:
+        * `create`: Perform the HTTP request when the resource is created.
+        * `delete`: Perform the HTTP request when the resource is deleted.
+    {{</ tf_arg >}}
+{{</ tf_arguments >}}

--- a/examples/service-http-post/main.tf
+++ b/examples/service-http-post/main.tf
@@ -1,0 +1,19 @@
+provider "dcos" {}
+
+locals {
+  github_user  = "some-user"
+  github_token = "some-token"
+}
+
+resource "dcos_service_http_request" "jenkins_credentials" {
+  service_name = module.jenkins.service_name
+  path         = "/credentials/store/system/domain/_/createCredentials"
+  method       = "POST"
+
+  header {
+    name  = "Content-Type"
+    value = "application/x-www-form-urlencoded"
+  }
+
+  body = "json={\"credentials\":{\"scope\":\"GLOBAL\", \"username\":\"'${local.github_user}'\", \"password\":\"'${local.github_token}'\", \"id\":\"GitHubUserWithToken\", \"description\":\"GitHub user and pass/token to download repositories \", \"stapler-class\":\"com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl\"}}&Submit=OK"
+}


### PR DESCRIPTION
This PR adds a new `dcos_service_http_request` resource that can be used to perform HTTP(s) requests to various DC/OS services, through the admin-router service entry point.

Example usage:
```tf
resource "dcos_service_http_request" "some_config" {
  service_name = "my-service"
  path         = "/configure"
  method       = "POST"

  header {
    name  = "Content-Type"
    value = "application/json"
  }

  body = <<EOF
    {
        "setting-a": "foo",
        "setting-b": "bar"
    }
EOF
```
